### PR TITLE
Remove tkinter dependency to fix gitpod

### DIFF
--- a/snake.py
+++ b/snake.py
@@ -2,8 +2,6 @@ import math
 import random
 import pygame
 import random
-import tkinter as tk
-from tkinter import messagebox
 
 width = 500
 height = 500


### PR DESCRIPTION
It's beyond my understanding why this doesn't work in gitpod with message:
```Hello from the pygame community. https://www.pygame.org/contribute.html
Traceback (most recent call last):
  File "/workspace/Snake-Game/snake.py", line 5, in <module>
    import tkinter as tk
  File "/home/gitpod/.pyenv/versions/3.7.7/lib/python3.7/tkinter/__init__.py", line 36, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
ModuleNotFoundError: No module named '_tkinter'
``
This is a proposed fix.